### PR TITLE
Create unsigned transfers

### DIFF
--- a/src/wallets/WalletContractV1R1.spec.ts
+++ b/src/wallets/WalletContractV1R1.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV1R1 } from "./WalletContractV1R1";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV1R1', () => {
     
@@ -46,5 +47,30 @@ describe('WalletContractV1R1', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV1R1.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            message: internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV1R1.ts
+++ b/src/wallets/WalletContractV1R1.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV1 } from "./signing/createWalletTransfer";
+import { createSigningMessageV1, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV1R1 implements Contract {
 
@@ -76,11 +76,11 @@ export class WalletContractV1R1 implements Contract {
     }
 
     /**
-     * Create signed transfer
+     * Create transfer
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         message?: Maybe<MessageRelaxed>,
         sendMode?: Maybe<SendMode>,
     }) {
@@ -88,12 +88,22 @@ export class WalletContractV1R1 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV1({
+        const signingMessage = createSigningMessageV1({
             seqno: args.seqno,
             sendMode,
-            secretKey: args.secretKey,
-            message: args.message
+            message: args.message,
         });
+
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage,
+            });
+        }
     }
 
     /**

--- a/src/wallets/WalletContractV1R2.spec.ts
+++ b/src/wallets/WalletContractV1R2.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV1R2 } from "./WalletContractV1R2";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV1R2', () => {
     it('should has balance and correct address', async () => {
@@ -44,5 +45,30 @@ describe('WalletContractV1R2', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV1R2.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            message: internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV1R2.ts
+++ b/src/wallets/WalletContractV1R2.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV1 } from "./signing/createWalletTransfer";
+import { createSigningMessageV1, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV1R2 implements Contract {
 
@@ -81,7 +81,7 @@ export class WalletContractV1R2 implements Contract {
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         message?: Maybe<MessageRelaxed>,
         sendMode?: Maybe<SendMode>,
     }) {
@@ -89,12 +89,22 @@ export class WalletContractV1R2 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV1({
+        const signingMessage = createSigningMessageV1({
             seqno: args.seqno,
             sendMode,
-            secretKey: args.secretKey,
-            message: args.message
+            message: args.message,
         });
+
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage,
+            });
+        }
     }
 
     /**

--- a/src/wallets/WalletContractV1R3.spec.ts
+++ b/src/wallets/WalletContractV1R3.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV1R3 } from "./WalletContractV1R3";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV1R3', () => {
     it('should has balance and correct address', async () => {
@@ -44,5 +45,29 @@ describe('WalletContractV1R3', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV1R3.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            message: internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV1R3.ts
+++ b/src/wallets/WalletContractV1R3.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV1 } from "./signing/createWalletTransfer";
+import { createSigningMessageV1, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV1R3 implements Contract {
 
@@ -77,11 +77,11 @@ export class WalletContractV1R3 implements Contract {
     }
 
     /**
-     * Create signed transfer
+     * Create transfer
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         message?: Maybe<MessageRelaxed>
         sendMode?: Maybe<SendMode>,
     }) {
@@ -89,12 +89,22 @@ export class WalletContractV1R3 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV1({
+        const signingMessage = createSigningMessageV1({
             seqno: args.seqno,
-            sendMode: sendMode,
-            secretKey: args.secretKey,
-            message: args.message
+            sendMode,
+            message: args.message,
         });
+
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage,
+            });
+        }
     }
 
     /**

--- a/src/wallets/WalletContractV2R1.spec.ts
+++ b/src/wallets/WalletContractV2R1.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV2R1 } from "./WalletContractV2R1";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV2R1', () => {
     it('should has balance and correct address', async () => {
@@ -44,5 +45,30 @@ describe('WalletContractV2R1', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV2R1.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            messages: [internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })]
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV2R1.ts
+++ b/src/wallets/WalletContractV2R1.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV2 } from "./signing/createWalletTransfer";
+import { createSigningMessageV2, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV2R1 implements Contract {
 
@@ -78,11 +78,11 @@ export class WalletContractV2R1 implements Contract {
     }
 
     /**
-     * Create signed transfer
+     * Create transfer
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         messages: MessageRelaxed[],
         sendMode?: Maybe<SendMode>,
         timeout?: Maybe<number>
@@ -91,13 +91,23 @@ export class WalletContractV2R1 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV2({
+        const signingMessage = createSigningMessageV2({
             seqno: args.seqno,
             sendMode,
-            secretKey: args.secretKey,
             messages: args.messages,
-            timeout: args.timeout
+            timeout: args.timeout,
         });
+
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage,
+            });
+        }
     }
 
     /**

--- a/src/wallets/WalletContractV2R2.spec.ts
+++ b/src/wallets/WalletContractV2R2.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV2R2 } from "./WalletContractV2R2";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV2R2', () => {
     it('should has balance and correct address', async () => {
@@ -44,5 +45,30 @@ describe('WalletContractV2R2', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV2R2.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            messages: [internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })]
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV2R2.ts
+++ b/src/wallets/WalletContractV2R2.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV2 } from "./signing/createWalletTransfer";
+import { createSigningMessageV2, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV2R2 implements Contract {
 
@@ -78,11 +78,11 @@ export class WalletContractV2R2 implements Contract {
     }
 
     /**
-     * Create signed transfer
+     * Create transfer
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         messages: MessageRelaxed[],
         sendMode?: Maybe<SendMode>,
         timeout?: Maybe<number>
@@ -91,13 +91,24 @@ export class WalletContractV2R2 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV2({
+
+        const signingMessage = createSigningMessageV2({
             seqno: args.seqno,
             sendMode,
-            secretKey: args.secretKey,
             messages: args.messages,
-            timeout: args.timeout
+            timeout: args.timeout,
         });
+
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage,
+            });
+        }
     }
 
     /**

--- a/src/wallets/WalletContractV3R1.spec.ts
+++ b/src/wallets/WalletContractV3R1.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV3R1 } from "./WalletContractV3R1";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV3R1', () => {
     it('should has balance and correct address', async () => {
@@ -44,5 +45,30 @@ describe('WalletContractV3R1', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV3R1.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            messages: [internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })]
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV3R1.ts
+++ b/src/wallets/WalletContractV3R1.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV3 } from "./signing/createWalletTransfer";
+import { createSigningMessageV3, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV3R1 implements Contract {
 
@@ -91,7 +91,7 @@ export class WalletContractV3R1 implements Contract {
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         messages: MessageRelaxed[],
         sendMode?: Maybe<SendMode>,
         timeout?: Maybe<number>
@@ -100,14 +100,24 @@ export class WalletContractV3R1 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV3({
+        const signingMessage = createSigningMessageV3({
             seqno: args.seqno,
             sendMode,
-            secretKey: args.secretKey,
             messages: args.messages,
             timeout: args.timeout,
             walletId: this.walletId
         });
+
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage,
+            });
+        }
     }
 
     /**

--- a/src/wallets/WalletContractV3R2.spec.ts
+++ b/src/wallets/WalletContractV3R2.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
 import { WalletContractV3R2 } from "./WalletContractV3R2";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV3R1', () => {
 
@@ -46,5 +47,30 @@ describe('WalletContractV3R1', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV3R2.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            messages: [internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello, world!'
+            })]
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV4.spec.ts
+++ b/src/wallets/WalletContractV4.spec.ts
@@ -10,6 +10,7 @@ import { randomTestKey } from "../utils/randomTestKey";
 import { WalletContractV4 } from "./WalletContractV4";
 import { createTestClient4 } from "../utils/createTestClient4";
 import { Address, internal } from "ton-core";
+import { createTestClient } from "../utils/createTestClient";
 
 describe('WalletContractV4', () => {
     
@@ -50,5 +51,34 @@ describe('WalletContractV4', () => {
 
         // Perform transfer
         await contract.send(transfer);
+    });
+
+    it('should perform estimation', async () => {
+        // Create contract
+        let client = createTestClient();
+        let contract = client.open(WalletContractV4.create({ workchain: 0, publicKey: randomTestKey('v4-treasure').publicKey }));
+
+        // Prepare transfer
+        let seqno = await contract.getSeqno();
+        let transfer = contract.createTransfer({
+            seqno,
+            messages: [internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello world: 1'
+            }), internal({
+                to: 'kQD6oPnzaaAMRW24R8F0_nlSsJQni0cGHntR027eT9_sgtwt',
+                value: '0.1',
+                body: 'Hello world: 2'
+            })]
+        });
+
+        // Perform estimation
+        await client.estimateExternalMessageFee(contract.address, {
+            body: transfer,
+            initCode: contract.init.code,
+            initData: contract.init.data,
+            ignoreSignature: true
+        });
     });
 });

--- a/src/wallets/WalletContractV4.ts
+++ b/src/wallets/WalletContractV4.ts
@@ -8,7 +8,7 @@
 
 import { Address, beginCell, Cell, Contract, contractAddress, ContractProvider, internal, MessageRelaxed, Sender, SendMode } from "ton-core";
 import { Maybe } from "../utils/maybe";
-import { createWalletTransferV4 } from "./signing/createWalletTransfer";
+import { createSigningMessageV4, createSigningTransferMessage, createUnSigningTransferMessage } from "./signing/createWalletTransfer";
 
 export class WalletContractV4 implements Contract {
 
@@ -88,11 +88,11 @@ export class WalletContractV4 implements Contract {
     }
 
     /**
-     * Create signed transfer
+     * Create transfer
      */
     createTransfer(args: {
         seqno: number,
-        secretKey: Buffer,
+        secretKey?: Buffer,
         messages: MessageRelaxed[]
         sendMode?: Maybe<SendMode>,
         timeout?: Maybe<number>,
@@ -101,14 +101,23 @@ export class WalletContractV4 implements Contract {
         if (args.sendMode !== null && args.sendMode !== undefined) {
             sendMode = args.sendMode;
         }
-        return createWalletTransferV4({
+        const signingMessage = createSigningMessageV4({
             seqno: args.seqno,
             sendMode,
-            secretKey: args.secretKey,
             messages: args.messages,
             timeout: args.timeout,
             walletId: this.walletId
         });
+        if (args.secretKey) {
+            return createSigningTransferMessage({
+                secretKey: args.secretKey,
+                signingMessage,
+            });
+        } else {
+            return createUnSigningTransferMessage({
+                signingMessage
+            });
+        }
     }
 
     /**


### PR DESCRIPTION
Make `secretKey` is optional for `createTransfer` to have an option to create unsigned transfers for estimations

Fixed: https://github.com/ton-core/ton/issues/8