### PR TITLE
Zod, safeParse, Trx - The 'message' field is missing

### DIFF
--- a/src/client/api/HttpApi.ts
+++ b/src/client/api/HttpApi.ts
@@ -84,7 +84,8 @@ const message = z.object({
     ihr_fee: z.string(),
     created_lt: z.string(),
     body_hash: z.string(),
-    msg_data: messageData
+    msg_data: messageData,
+    message: z.string()
 });
 
 const transaction = z.object({


### PR DESCRIPTION
The 'message' field is missing - responsible for the message attached to the transaction. As a result, the 'getTransactions' method will return information without this field.